### PR TITLE
docs: add release changelog and agent update workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,18 @@ README.md                         # user-facing usage + caveats
 - `go vet ./...` passes
 - smoke at least one command on each touched provider path
 - README updated for user-visible changes
+- CHANGELOG updated for user-visible changes
+
+## Changelog workflow
+
+- Keep `CHANGELOG.md` in a simple release-notes format with `## [Unreleased]` at the top.
+- Add user-facing changes under `Unreleased` using sections in this order: `Added`, `Changed`, `Fixed`, `Docs`, `Security`.
+- Keep entries concise and action-oriented (what changed for users, not internal refactors unless user impact exists).
+- On release, move `Unreleased` items into `## [vX.Y.Z] - YYYY-MM-DD` and update compare links at the bottom.
+- If a section has no updates while editing, use `- None yet.` to keep structure stable.
 
 ## Maintenance note
 
-- Keep `README.md` and `AGENTS.md` aligned when commands, routing, caveats, or folder structure change.
+- Keep `README.md`, `AGENTS.md`, and `CHANGELOG.md` aligned when commands, routing, caveats, or release-relevant behavior change.
 
 Do not commit transient binaries like `./defi`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable user-facing changes to `defi-cli` are documented in this file.
+
+Format:
+- Keep entries under `Unreleased` until a tag is cut.
+- Group notes by section in this order: `Added`, `Changed`, `Fixed`, `Docs`, `Security`.
+- Keep bullets short and focused on user impact.
+
+## [Unreleased]
+
+### Added
+- None yet.
+
+### Changed
+- None yet.
+
+### Fixed
+- None yet.
+
+### Docs
+- None yet.
+
+### Security
+- None yet.
+
+## [v0.1.1] - 2026-02-21
+
+### Changed
+- Installer now defaults to writable user-space `PATH` locations and does not use `sudo` unless explicitly requested.
+
+### Docs
+- Refreshed README structure and feature overview.
+
+## [v0.1.0] - 2026-02-21
+
+### Added
+- First tagged release of `defi-cli`.
+- Core command surface for chains, protocols, assets, lending, yield, bridge, and swap workflows.
+- Stable JSON envelope output and deterministic exit code contract for automation.
+
+### Changed
+- Project/module path migrated to `github.com/ggonzalez94/defi-cli`.
+
+[Unreleased]: https://github.com/ggonzalez94/defi-cli/compare/v0.1.1...HEAD
+[v0.1.1]: https://github.com/ggonzalez94/defi-cli/compare/v0.1.0...v0.1.1
+[v0.1.0]: https://github.com/ggonzalez94/defi-cli/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- add a root CHANGELOG.md with an Unreleased template for release notes
- backfill entries for v0.1.0 and v0.1.1
- update AGENTS.md quality bar and maintenance guidance so agents keep changelog entries up to date

## Testing
- docs-only change (no code/tests run)