### PR TITLE
feat(cache): prune expired entries on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format:
 ## [Unreleased]
 
 ### Added
+- Cache auto-pruning: expired entries (past TTL + `max_stale`) are automatically deleted on startup to prevent unbounded `cache.db` growth.
 - Added Tempo chain normalization, RPC defaults, and bootstrap stablecoin registries for mainnet (`tempo`/`presto`), Moderato testnet, and Tempo devnet.
 - Added the `tempo` swap provider with on-chain quote and execution planning against the Tempo Stablecoin DEX, including `exact-input` and `exact-output` support.
 - Added Tempo coverage to generic ERC-20 approval and transfer planning through shared chain/token registry support.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ providers:
 - If fallback is disabled (`--no-stale` or `--max-stale 0s`) or stale data exceeds the budget, the CLI exits with code `14`.
 - Metadata commands (`version`, `schema`, `providers list`) bypass cache initialization.
 - Execution commands (`swap|bridge|approvals|transfer|lend|yield|rewards ... plan|submit|status`, `actions list|show|estimate`) bypass cache reads/writes.
+- Expired entries (past TTL + `max_stale`) are automatically pruned on startup to prevent unbounded growth.
 
 ## Caveats
 

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -205,7 +205,7 @@ func (s *runtimeState) newRootCommand() *cobra.Command {
 			}
 
 			if settings.CacheEnabled && shouldOpenCache(path) && s.cache == nil {
-				cacheStore, err := cache.Open(settings.CachePath, settings.CacheLockPath)
+				cacheStore, err := cache.Open(settings.CachePath, settings.CacheLockPath, settings.MaxStale)
 				if err != nil {
 					// Cache should be best-effort; continue without it if initialization fails.
 					s.settings.CacheEnabled = false

--- a/internal/app/runner_cache_policy_test.go
+++ b/internal/app/runner_cache_policy_test.go
@@ -229,7 +229,7 @@ func TestRunCachedCommandStrictPartialErrorPreservesDiagnostics(t *testing.T) {
 func newCachePolicyTestState(t *testing.T, maxStale time.Duration, noStale bool) (*runtimeState, *bytes.Buffer) {
 	t.Helper()
 	tmp := t.TempDir()
-	store, err := cache.Open(filepath.Join(tmp, "cache.db"), filepath.Join(tmp, "cache.lock"))
+	store, err := cache.Open(filepath.Join(tmp, "cache.db"), filepath.Join(tmp, "cache.lock"), maxStale)
 	if err != nil {
 		t.Fatalf("open cache failed: %v", err)
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -34,7 +34,7 @@ const (
 	sqliteRetryBase    = 10 * time.Millisecond
 )
 
-func Open(path, lockPath string) (*Store, error) {
+func Open(path, lockPath string, maxStale time.Duration) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("create cache directory: %w", err)
 	}
@@ -70,7 +70,12 @@ func Open(path, lockPath string) (*Store, error) {
 		}
 	}
 
-	return &Store{db: db, lock: lock}, nil
+	store := &Store{db: db, lock: lock}
+	// Prune entries that are past both TTL and max_stale on startup to
+	// prevent unbounded growth while preserving the stale fallback window.
+	// Best-effort: a prune failure should not prevent cache usage.
+	_ = store.pruneUnlocked(maxStale)
+	return store, nil
 }
 
 func (s *Store) Close() error {
@@ -78,6 +83,38 @@ func (s *Store) Close() error {
 		return nil
 	}
 	return s.db.Close()
+}
+
+// Prune deletes cache entries that are past both their TTL and the max_stale
+// fallback window. Entries within (ttl, ttl+maxStale] are preserved so that
+// runCachedCommand can serve them during temporary provider failures.
+// It is called automatically on Open and can be called manually.
+func (s *Store) Prune(maxStale time.Duration) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	unlock, err := acquireFileLock(s.lock, lockAcquireTimeout)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return s.pruneUnlocked(maxStale)
+}
+
+// pruneUnlocked performs the prune without acquiring the file lock.
+// The caller must hold the lock (or be in a context where locking is
+// already guaranteed, such as during Open).
+func (s *Store) pruneUnlocked(maxStale time.Duration) error {
+	maxStaleSec := int64(maxStale.Seconds())
+	if maxStaleSec < 0 {
+		maxStaleSec = 0
+	}
+	nowUnix := time.Now().UTC().Unix()
+	err := execWithRetry(s.db, "DELETE FROM cache_entries WHERE created_at + ttl_seconds + ? < ?", maxStaleSec, nowUnix)
+	if err != nil {
+		return fmt.Errorf("prune cache: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) Get(key string, maxStale time.Duration) (Result, error) {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCacheSetGetFreshAndStale(t *testing.T) {
 	tmp := t.TempDir()
-	store, err := Open(filepath.Join(tmp, "cache.db"), filepath.Join(tmp, "cache.lock"))
+	store, err := Open(filepath.Join(tmp, "cache.db"), filepath.Join(tmp, "cache.lock"), 5*time.Minute)
 	if err != nil {
 		t.Fatalf("Open cache failed: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestCacheSetGetFreshAndStale(t *testing.T) {
 
 func TestCacheTooStale(t *testing.T) {
 	tmp := t.TempDir()
-	store, err := Open(filepath.Join(tmp, "cache.db"), filepath.Join(tmp, "cache.lock"))
+	store, err := Open(filepath.Join(tmp, "cache.db"), filepath.Join(tmp, "cache.lock"), 5*time.Minute)
 	if err != nil {
 		t.Fatalf("Open cache failed: %v", err)
 	}
@@ -59,6 +59,103 @@ func TestCacheTooStale(t *testing.T) {
 	}
 }
 
+func TestPruneRemovesExpiredEntries(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := Open(filepath.Join(tmp, "cache.db"), filepath.Join(tmp, "cache.lock"), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("Open cache failed: %v", err)
+	}
+	defer store.Close()
+
+	// Insert an entry with a very short TTL.
+	if err := store.Set("prunable", []byte(`"old"`), 1*time.Second); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	// Insert a long-lived entry.
+	if err := store.Set("keeper", []byte(`"keep"`), 1*time.Hour); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Wait long enough for the 1s TTL to fully expire at Unix-second
+	// granularity. 1200ms can land in the same second as creation;
+	// 2100ms guarantees at least one full second has elapsed.
+	time.Sleep(2100 * time.Millisecond)
+
+	// Prune with zero max_stale so expired entries are removed immediately.
+	if err := store.Prune(0); err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+
+	// The expired entry should be gone (miss).
+	res, err := store.Get("prunable", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Get prunable failed: %v", err)
+	}
+	if res.Hit {
+		t.Fatalf("expected prunable to be evicted, but got hit")
+	}
+
+	// The long-lived entry should still be there.
+	res, err = store.Get("keeper", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Get keeper failed: %v", err)
+	}
+	if !res.Hit {
+		t.Fatalf("expected keeper to still be present")
+	}
+}
+
+func TestPrunePreservesStaleWithinMaxStale(t *testing.T) {
+	tmp := t.TempDir()
+	// Use a short max_stale for Open so startup prune does not interfere.
+	store, err := Open(filepath.Join(tmp, "cache.db"), filepath.Join(tmp, "cache.lock"), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("Open cache failed: %v", err)
+	}
+	defer store.Close()
+
+	// Insert an entry with 1s TTL — it will expire quickly but should
+	// remain within a generous max_stale window.
+	if err := store.Set("stale-ok", []byte(`"fallback"`), 1*time.Second); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Wait for TTL to expire.
+	time.Sleep(2100 * time.Millisecond)
+
+	// Prune with a large max_stale window; the stale entry should survive.
+	if err := store.Prune(10 * time.Minute); err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+
+	res, err := store.Get("stale-ok", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("Get stale-ok failed: %v", err)
+	}
+	if !res.Hit {
+		t.Fatalf("expected stale-ok to be preserved within max_stale window, but got miss")
+	}
+	if !res.Stale {
+		t.Fatalf("expected stale-ok to be stale, got fresh")
+	}
+	if res.TooStale {
+		t.Fatalf("expected stale-ok to be within max_stale, got TooStale")
+	}
+
+	// Now prune with zero max_stale — the entry should be removed.
+	if err := store.Prune(0); err != nil {
+		t.Fatalf("Prune (zero max_stale) failed: %v", err)
+	}
+
+	res, err = store.Get("stale-ok", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("Get stale-ok after zero-max-stale prune failed: %v", err)
+	}
+	if res.Hit {
+		t.Fatalf("expected stale-ok to be evicted after zero max_stale prune, but got hit")
+	}
+}
+
 func TestCacheConcurrentOpenAndSet(t *testing.T) {
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "cache.db")
@@ -74,7 +171,7 @@ func TestCacheConcurrentOpenAndSet(t *testing.T) {
 		go func(workerID int) {
 			defer wg.Done()
 
-			store, err := Open(dbPath, lockPath)
+			store, err := Open(dbPath, lockPath, 5*time.Minute)
 			if err != nil {
 				errCh <- fmt.Errorf("worker %d open: %w", workerID, err)
 				return


### PR DESCRIPTION
## What

Adds a `Prune()` method to `cache.Store` that deletes all rows where `created_at + ttl_seconds < now()`. It is called automatically during `Open()` so that every CLI invocation cleans up stale data before proceeding.

## Why

The cache currently grows indefinitely — entries are written with TTL metadata but never deleted. For agents or scripts calling the CLI frequently, `cache.db` accumulates stale rows without bound.

## Changes

- `internal/cache/cache.go`: Add `Prune()` method; call it in `Open()`
- `internal/cache/cache_test.go`: Add `TestPruneRemovesExpiredEntries`

Closes #5