### PR TITLE
fix(lend): mark --protocol, --chain, --asset as required cobra flags

### DIFF
--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -511,7 +511,7 @@ func (s *runtimeState) newLendCommand() *cobra.Command {
 	marketsCmd.Flags().StringVar(&chainArg, "chain", "", "Chain identifier")
 	marketsCmd.Flags().StringVar(&assetArg, "asset", "", "Asset (symbol/address/CAIP-19)")
 	marketsCmd.Flags().IntVar(&marketsLimit, "limit", 20, "Maximum lending markets to return")
-	_ = marketsCmd.MarkFlagRequired("protocol")
+	_ = marketsCmd.MarkFlagRequired("provider")
 	_ = marketsCmd.MarkFlagRequired("chain")
 	_ = marketsCmd.MarkFlagRequired("asset")
 
@@ -552,7 +552,7 @@ func (s *runtimeState) newLendCommand() *cobra.Command {
 	ratesCmd.Flags().StringVar(&ratesChain, "chain", "", "Chain identifier")
 	ratesCmd.Flags().StringVar(&ratesAsset, "asset", "", "Asset (symbol/address/CAIP-19)")
 	ratesCmd.Flags().IntVar(&ratesLimit, "limit", 20, "Maximum lending rates to return")
-	_ = ratesCmd.MarkFlagRequired("protocol")
+	_ = ratesCmd.MarkFlagRequired("provider")
 	_ = ratesCmd.MarkFlagRequired("chain")
 	_ = ratesCmd.MarkFlagRequired("asset")
 
@@ -629,6 +629,9 @@ func (s *runtimeState) newLendCommand() *cobra.Command {
 	positionsCmd.Flags().StringVar(&positionsAsset, "asset", "", "Optional asset filter (symbol/address/CAIP-19)")
 	positionsCmd.Flags().StringVar(&positionsType, "type", string(providers.LendPositionTypeAll), "Position type filter (all|supply|borrow|collateral)")
 	positionsCmd.Flags().IntVar(&positionsLimit, "limit", 20, "Maximum positions to return")
+	_ = positionsCmd.MarkFlagRequired("provider")
+	_ = positionsCmd.MarkFlagRequired("chain")
+	_ = positionsCmd.MarkFlagRequired("address")
 
 	root.AddCommand(marketsCmd)
 	root.AddCommand(ratesCmd)


### PR DESCRIPTION
## What

Adds `MarkFlagRequired` calls for `--provider`, `--chain`, and `--asset` on `lend markets` and `lend rates`, and `--provider`, `--chain`, `--address` on `lend positions`.

## Why

These flags are validated manually in the `RunE` handlers, but Cobra didn't know they're required. This means:
- `defi lend markets --help` didn't show them as required
- `defi schema lend markets` didn't reflect them in machine-readable output
- Error messages were less standard than Cobra's built-in required flag errors

Other commands like `bridge quote` and `yield opportunities` already use `MarkFlagRequired` correctly.

## Changes

- `internal/app/runner.go`: Add `MarkFlagRequired` for `--provider`/`--chain`/`--asset` on `marketsCmd` and `ratesCmd`; add `MarkFlagRequired` for `--provider`/`--chain`/`--address` on `positionsCmd`

The manual validation in `RunE` is kept as defense-in-depth (it also handles normalization).

## Structured input note

These are read-only commands that do not support `--input-json` / `--input-file`, so the `MarkFlagRequired` + structured input interaction (where Cobra would reject missing flags before `PreRunE` applies structured input) does not apply here.

Closes #7